### PR TITLE
✨ Feature/#14 schedule calendar

### DIFF
--- a/src/components/common/Calendar/CalendarTileContent.tsx
+++ b/src/components/common/Calendar/CalendarTileContent.tsx
@@ -15,7 +15,7 @@ function CalendarTileContent({ filterIdols }: Props) {
   const type = TYPE_LABEL[filterIdols];
 
   return (
-    <div>
+    <div className="overflow-hidden text-ellipsis whitespace-nowrap">
       <span className={`text-white ${type.color} p-2`}>{filterIdols}</span>
     </div>
   );

--- a/src/components/common/Calendar/CalendarTileContent.tsx
+++ b/src/components/common/Calendar/CalendarTileContent.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+type Props = {
+  filterIdols: string;
+};
+
+const TYPE_LABEL = {
+  팬미팅: { color: 'bg-blue-500' },
+  공연: { color: 'bg-red-500' },
+  방송: { color: 'bg-green-500' },
+  Etc: { color: 'bg-gray-400' },
+};
+
+function CalendarTileContent({ filterIdols }: Props) {
+  const type = TYPE_LABEL[filterIdols];
+
+  return (
+    <div>
+      <span className={`text-white ${type.color} p-2`}>{filterIdols}</span>
+    </div>
+  );
+}
+
+export default CalendarTileContent;

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,0 +1,44 @@
+import { format } from 'date-fns';
+import { useState } from 'react';
+import Calendar, { TileArgs } from 'react-calendar';
+import { Idol } from '@store/idolStore';
+import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent.tsx';
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+type Props = {
+  idols: Idol[];
+};
+
+function CalendarWrapper({ idols }: Props) {
+  const [value, onChange] = useState<Value>(new Date());
+
+  const makeTileContent = ({ date }: TileArgs) => {
+    const titleDate = format(date, 'yyyy-MM-dd');
+    const filtered = idols.filter(item => item.startDate === titleDate);
+    const type = filtered.map(item => item.type);
+    return (
+      <div className="flex h-full flex-col">
+        <div className="mt-2 flex max-h-[100px] flex-col overflow-hidden">
+          {type.map(item => (
+            <CalendarTileContent filterIdols={item} key={item} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <article>
+      <Calendar
+        locale="ko"
+        value={value}
+        onChange={onChange}
+        tileContent={makeTileContent}
+      />
+    </article>
+  );
+}
+
+export default CalendarWrapper;

--- a/src/components/common/IdolDropdownPanel.tsx
+++ b/src/components/common/IdolDropdownPanel.tsx
@@ -1,7 +1,18 @@
 import { Link } from 'react-router';
 
+type Idol = {
+  id: number;
+  idolId: number;
+  title: string;
+  type: string;
+  startDate: string;
+  endDate: string;
+  location: string;
+  description: string;
+};
+
 type Props = {
-  idols: { id: number; name: string }[];
+  idols: Idol[];
   selectedIdolId: number | null;
   setSelectIdol: (idolId: number) => void;
 };
@@ -18,7 +29,7 @@ function IdolDropdownPanel({ idols, selectedIdolId, setSelectIdol }: Props) {
               selectedIdolId === idol.id && 'bg-gray-100'
             }`}
           >
-            {idol.name}
+            {idol.title}
           </button>
         </div>
       ))}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,8 +20,8 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full bg-white">
-      <div className="mx-auto flex max-w-[1080px] items-center justify-between p-4">
+    <header className="fixed z-[9999] w-full max-w-[1080px] bg-red-200">
+      <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">
             <h1 className="pb-2 text-3xl leading-none font-bold">Wistar</h1>
@@ -30,7 +30,7 @@ function Header() {
           <Dropdown
             isDropdownOpen={isDropdownOpen}
             handleOnToggle={handleOnToggle}
-            selectedIdol={selectedIdol?.name ?? '아이돌 선택'}
+            selectedIdol={selectedIdol?.title ?? '아이돌 선택'}
           >
             <IdolDropdownPanel
               idols={idols}
@@ -49,7 +49,7 @@ function Header() {
             ))}
           </nav>
         ) : (
-          <div>
+          <div className="ml-auto">
             <button
               type="button"
               onClick={() => setIsOpen(prev => !prev)}

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -6,7 +6,9 @@ function Layout() {
   return (
     <div>
       <Header />
-      <Outlet />
+      <main className="py-8">
+        <Outlet />
+      </main>
       <Footer />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,77 @@
 @import "tailwindcss";
 
 @layer base {
-    root {
+    html,body {
         @apply max-w-[1080px] mx-auto;
+    }
+}
+
+@layer components {
+    /* 전체 캘린더 박스 */
+    .react-calendar {
+        @apply flex flex-col items-center text-center  max-h-[600px] border border-gray-200 p-4 shadow-md;
+    }
+
+    /* navigation 영역 (월/연 이동) */
+    .react-calendar__navigation {
+        @apply flex justify-between items-center w-full text-lg mb-4;
+    }
+
+    /* navigation 버튼 공통 스타일 */
+    .react-calendar__navigation button {
+        @apply cursor-pointer px-4;
+    }
+
+    /* navigation - prev, next 버튼 */
+    .react-calendar__navigation__prev-button,
+    .react-calendar__navigation__next-button {
+        @apply px-4;
+    }
+
+    /* navigation - prev2, next2 버튼 숨기기 (10년 이동 버튼) */
+    .react-calendar__navigation__prev2-button,
+    .react-calendar__navigation__next2-button {
+        @apply hidden;
+    }
+
+    /* navigation label 텍스트 정리 */
+    .react-calendar__navigation__label {
+        @apply mx-4;
+    }
+
+    /* 요일(일,월,화,수) 줄 */
+    .react-calendar__month-view__weekdays {
+        @apply flex justify-center max-h-[200px];
+    }
+
+    /* 요일(일,월,화,수) 글자 */
+    .react-calendar__month-view__weekdays__weekday {
+        @apply text-center text-lg mt-4;
+    }
+
+    /* 요일 글자 데코 제거 (밑줄 없애기) */
+    .react-calendar__month-view__weekdays__weekday abbr {
+        text-decoration: none;
+    }
+
+    /* 오늘 날짜 강조 */
+    .react-calendar__tile--now {
+        @apply font-bold bg-red-500 text-white;
+    }
+
+    /* 오늘 날짜 클릭했을 때, hover했을 때 */
+    .react-calendar__tile--now:active,
+    .react-calendar__tile--now:hover {
+        @apply bg-black text-white;
+    }
+
+    /* 활성화된(선택된) 날짜 */
+    .react-calendar__tile--active {
+        @apply bg-black text-white;
+    }
+
+    /* 날짜 타일 스타일 */
+    .react-calendar__month-view__days__day {
+        @apply mt-4 py-2 rounded-md hover:bg-red-200 transition;
     }
 }

--- a/src/pages/schedule/Schedule.tsx
+++ b/src/pages/schedule/Schedule.tsx
@@ -1,5 +1,29 @@
+import { useIdolState } from '@store/idolStore';
+import CalendarWrapper from '@/components/common/Calendar/CalendarWrapper';
+
 function Schedule() {
-  return <div>Schedule</div>;
+  const { idols } = useIdolState();
+  const isLogin = true;
+
+  const publicIdols = [
+    {
+      id: 99,
+      idolId: 99,
+      title: 'K-POP 축제',
+      type: '공연',
+      startDate: '2025-05-25',
+      endDate: '2025-05-25',
+      location: '서울 월드컵 경기장',
+      description: 'K-POP 슈퍼 콘서트',
+    },
+  ];
+
+  const displayIdols = isLogin ? idols : publicIdols;
+  return (
+    <section className="mt-20 px-2">
+      <CalendarWrapper idols={displayIdols} />
+    </section>
+  );
 }
 
 export default Schedule;

--- a/src/store/idolStore.ts
+++ b/src/store/idolStore.ts
@@ -1,22 +1,62 @@
 import { create } from 'zustand/react';
 
+export type Idol = {
+  id: number;
+  idolId: number;
+  title: string;
+  type: string;
+  startDate: string;
+  endDate: string;
+  location: string;
+  description: string;
+};
+
 interface IdolState {
-  idols: { id: number; name: string }[];
+  idols: Idol[];
   selectedIdolId: number | null;
   setSelectIdol: (idolId: number) => void;
-  addIdol: (idol: { id: number; name: string }) => void;
+  addIdol: (idol: Idol) => void;
   removeIdol: (idolId: number) => void;
 }
 
+const idols: Idol[] = [
+  {
+    id: 1,
+    idolId: 1,
+    title: '트와이스 팬미팅',
+    type: '팬미팅',
+    startDate: '2025-05-03',
+    endDate: '2025-05-03',
+    location: '서울 올림픽홀',
+    description: '2025년 상반기 팬미팅',
+  },
+  {
+    id: 2,
+    idolId: 1,
+    title: '트와이스 콘서트',
+    type: '공연',
+    startDate: '2025-05-10',
+    endDate: '2025-05-10',
+    location: '부산 벡스코',
+    description: 'TWICE WORLD TOUR 2025',
+  },
+  {
+    id: 3,
+    idolId: 1,
+    title: '음방 출연 - 음악중심',
+    type: '방송',
+    startDate: '2025-05-18',
+    endDate: '2025-05-18',
+    location: 'MBC 상암동',
+    description: '음악중심 생방송 출연',
+  },
+];
+
 export const useIdolState = create<IdolState>(set => ({
-  idols: [
-    { id: 1, name: '트와이스' },
-    { id: 2, name: '레드벨벳' },
-    { id: 3, name: 'IVE' },
-  ],
+  idols,
   selectedIdolId: null,
   setSelectIdol: (id: number) => set({ selectedIdolId: id }),
-  addIdol: (idol: { id: number; name: string }) =>
+  addIdol: (idol: Idol) =>
     set(state => ({ idols: [...state.idols, { ...idol }] })),
   removeIdol: (idolId: number) =>
     set(state => ({ idols: state.idols.filter(id => id.id !== idolId) })),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#14 

## 📝작업 내용
- 스케줄(Schedule) 페이지 기본 구조 구현
- 로그인/비로그인 분기 처리(임시 처리)
- displayIdols로 데이터 분기 후 CalendarWrapper에 전달
- CalendarWrapper 컴포넌트 구현
- react-calendar 라이브러리 적용
- props로 일정(idols) 전달받아 날짜별 일정 표시
- CalendarTileContent 컴포넌트 구현
- 일정 종류(type)에 따라 라벨 스타일링 표시
- 아이돌 mock 데이터(idols) 구조 수정
- title, type, startDate, location 등 세부 정보 추가
- IdolDropdownPanel 수정
- 수정된 idol 데이터 타입에 맞춰 버튼 목록 렌더링
- Layout 컴포넌트에 <main> 태그 및 padding 스타일 추가
- 페이지 레이아웃 개선 (Schedule 페이지 반영을 위해)

### 스크린샷 (선택)
![스크린샷 2025-04-27 200353](https://github.com/user-attachments/assets/1c2cd7c9-fcee-41ce-b020-320a28daa117)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

