### PR TITLE
✨ Feature/#14 schedule notification

### DIFF
--- a/src/assets/icons/Arrow.tsx
+++ b/src/assets/icons/Arrow.tsx
@@ -1,0 +1,20 @@
+type Props = {
+  width?: number;
+  height?: number;
+  fill?: string;
+};
+function Arrow({ width = 48, height = 48, fill = 'none' }: Props) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 42 72"
+      fill={fill}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M15.75 18L26.25 36L15.75 54" stroke="#A4A4A4" />
+    </svg>
+  );
+}
+
+export default Arrow;

--- a/src/assets/icons/inedx.ts
+++ b/src/assets/icons/inedx.ts
@@ -1,2 +1,3 @@
 export { default as Hamburger } from './Hamburger';
 export { default as Close } from './Close';
+export { default as Arrow } from './Arrow';

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -15,10 +15,12 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
+  const today = format(new Date(), 'yyyy-MM-dd');
   const [selectedDate, setSelectedDate] = useState<
     Date | string | null | number
   >(null);
   const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
+  const upcomingIdols = idols.filter(idol => idol.startDate >= today);
 
   useEffect(() => {
     if (value instanceof Date) {
@@ -55,6 +57,11 @@ function CalendarWrapper({ idols }: Props) {
       />
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
+          <NotificationInfoCardList filterDate={idol} />
+        </NotificationCard>
+      ))}
+      {upcomingIdols?.map(idol => (
+        <NotificationCard key={`upcoming-${idol.id}`}>
           <NotificationInfoCardList filterDate={idol} />
         </NotificationCard>
       ))}

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,8 +1,10 @@
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Calendar, { TileArgs } from 'react-calendar';
+import NotificationCard from '@components/common/Card/NotificationCard';
+import NotificationInfoCardList from '@components/common/Card/NotificationInfoCardList';
 import { Idol } from '@store/idolStore';
-import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent.tsx';
+import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent';
 
 type ValuePiece = Date | null;
 
@@ -13,6 +15,20 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | string | number>(
+    null
+  );
+  const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
+
+  useEffect(() => {
+    if (value instanceof Date) {
+      setSelectedDate(format(value, 'yyyy-MM-dd'));
+    } else if (Array.isArray(value)) {
+      setSelectedDate(format(value[0], 'yyyy-MM-dd'));
+    } else {
+      setSelectedDate(null);
+    }
+  }, [value]);
 
   const makeTileContent = ({ date }: TileArgs) => {
     const titleDate = format(date, 'yyyy-MM-dd');
@@ -37,6 +53,11 @@ function CalendarWrapper({ idols }: Props) {
         onChange={onChange}
         tileContent={makeTileContent}
       />
+      {selectedIdol?.map(idol => (
+        <NotificationCard key={idol.id}>
+          <NotificationInfoCardList filterDate={idol} />
+        </NotificationCard>
+      ))}
     </article>
   );
 }

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -15,9 +15,9 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | string | number>(
-    null
-  );
+  const [selectedDate, setSelectedDate] = useState<
+    Date | string | null | number
+  >(null);
   const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
 
   useEffect(() => {
@@ -32,13 +32,13 @@ function CalendarWrapper({ idols }: Props) {
 
   const makeTileContent = ({ date }: TileArgs) => {
     const titleDate = format(date, 'yyyy-MM-dd');
-    const filtered = idols.filter(item => item.startDate === titleDate);
-    const type = filtered.map(item => item.type);
+    const filteredIdols = idols.filter(item => item.startDate === titleDate);
+    const types = filteredIdols.map(item => item.type);
     return (
       <div className="flex h-full flex-col">
         <div className="mt-2 flex max-h-[100px] flex-col overflow-hidden">
-          {type.map(item => (
-            <CalendarTileContent filterIdols={item} key={item} />
+          {types.map(type => (
+            <CalendarTileContent filterIdols={type} key={type} />
           ))}
         </div>
       </div>

--- a/src/components/common/Card/NotificationCard.tsx
+++ b/src/components/common/Card/NotificationCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function NotificationCard({ children }: Props) {
+  return (
+    <div className="mt-12 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
+      {children}
+    </div>
+  );
+}
+
+export default NotificationCard;

--- a/src/components/common/Card/NotificationInfoCardList.tsx
+++ b/src/components/common/Card/NotificationInfoCardList.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Arrow } from '@assets/icons/inedx.ts';
+import { Idol } from '@store/idolStore.ts';
+
+type Props = {
+  filterDate: Idol;
+};
+
+function NotificationInfoCardList({ filterDate }: Props) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-1">
+        <p className="text-lg font-bold">
+          {filterDate.type} & {filterDate.title}
+        </p>
+        <p className="truncate text-gray-500">{filterDate.description}</p>
+        <p className="text-gray-500">
+          {filterDate.location}: {filterDate.startDate} ~ {filterDate.endDate}
+        </p>
+      </div>
+      <div>
+        <Arrow />
+      </div>
+    </div>
+  );
+}
+
+export default NotificationInfoCardList;

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,7 +20,7 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full max-w-[1080px] bg-red-200">
+    <header className="fixed z-[9999] w-full max-w-[1080px]">
       <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#14
## 📝작업 내용
- CalendarWrapper 컴포넌트 내부 로직 개선
- selectedIdol → selectedIdols로 복수형 변수명 변경
- makeTileContent → renderTileContent로 네이밍 명확화
-NotificationCard 컴포넌트 추가
- 알림 카드 레이아웃 담당 (shadow, padding, rounded 처리)
- NotificationInfoCardList 컴포넌트 추가
- 알림 카드 내부 내용(제목, 설명, 일정 정보, 화살표) 정리
- flex 레이아웃 적용으로 모바일/PC 모두 자연스럽게 대응
- header 컴포넌트의 불필요한 bg 스타일 삭제
- 해당하는 아티스트에 대한 다가오늘 일정을 구현

### 스크린샷 (선택)
![스크린샷 2025-04-27 214748](https://github.com/user-attachments/assets/05ef131e-009c-4350-baa7-bacc58f66655)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
