### PR TITLE
✨ Feature/#14 schedule UI

### DIFF
--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -55,11 +55,13 @@ function CalendarWrapper({ idols }: Props) {
         onChange={onChange}
         tileContent={makeTileContent}
       />
+      <h3 className="mt-12 text-2xl font-bold">오늘의 스케줄</h3>
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
           <NotificationInfoCardList filterDate={idol} />
         </NotificationCard>
       ))}
+      <h3 className="mt-12 text-2xl font-bold">다가오는 스케줄</h3>
       {upcomingIdols?.map(idol => (
         <NotificationCard key={`upcoming-${idol.id}`}>
           <NotificationInfoCardList filterDate={idol} />

--- a/src/components/common/Card/NotificationCard.tsx
+++ b/src/components/common/Card/NotificationCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 function NotificationCard({ children }: Props) {
   return (
-    <div className="mt-12 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
+    <div className="mt-4 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
       {children}
     </div>
   );

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,7 +20,7 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full max-w-[1080px]">
+    <header className="fixed z-[9999] w-full max-w-[1080px] bg-white">
       <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
# 14
## 📝작업 내용
### CalendarWrapper 컴포넌트
- "오늘의 스케줄" / "다가오는 스케줄" 구분 섹션 추가
- 선택한 날짜(selectedIdol)와 다가오는 일정(upcomingIdols)을 구분해서 렌더링
- 스케줄 카드(NotificationCard) UI 구조 개선

### 스크린샷 (선택)
![스크린샷 2025-04-27 221704](https://github.com/user-attachments/assets/92584bb9-dfaa-4c6d-a4aa-62c176ea90b1)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
