### PR TITLE
✨ Feature/#14 schedule

### DIFF
--- a/src/assets/icons/Arrow.tsx
+++ b/src/assets/icons/Arrow.tsx
@@ -1,0 +1,20 @@
+type Props = {
+  width?: number;
+  height?: number;
+  fill?: string;
+};
+function Arrow({ width = 48, height = 48, fill = 'none' }: Props) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 42 72"
+      fill={fill}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M15.75 18L26.25 36L15.75 54" stroke="#A4A4A4" />
+    </svg>
+  );
+}
+
+export default Arrow;

--- a/src/assets/icons/inedx.ts
+++ b/src/assets/icons/inedx.ts
@@ -1,2 +1,3 @@
 export { default as Hamburger } from './Hamburger';
 export { default as Close } from './Close';
+export { default as Arrow } from './Arrow';

--- a/src/components/common/Calendar/CalendarTileContent.tsx
+++ b/src/components/common/Calendar/CalendarTileContent.tsx
@@ -15,7 +15,7 @@ function CalendarTileContent({ filterIdols }: Props) {
   const type = TYPE_LABEL[filterIdols];
 
   return (
-    <div>
+    <div className="overflow-hidden text-ellipsis whitespace-nowrap">
       <span className={`text-white ${type.color} p-2`}>{filterIdols}</span>
     </div>
   );

--- a/src/components/common/Calendar/CalendarTileContent.tsx
+++ b/src/components/common/Calendar/CalendarTileContent.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+type Props = {
+  filterIdols: string;
+};
+
+const TYPE_LABEL = {
+  팬미팅: { color: 'bg-blue-500' },
+  공연: { color: 'bg-red-500' },
+  방송: { color: 'bg-green-500' },
+  Etc: { color: 'bg-gray-400' },
+};
+
+function CalendarTileContent({ filterIdols }: Props) {
+  const type = TYPE_LABEL[filterIdols];
+
+  return (
+    <div>
+      <span className={`text-white ${type.color} p-2`}>{filterIdols}</span>
+    </div>
+  );
+}
+
+export default CalendarTileContent;

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -15,10 +15,12 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
+  const today = format(new Date(), 'yyyy-MM-dd');
   const [selectedDate, setSelectedDate] = useState<
     Date | string | null | number
   >(null);
   const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
+  const upcomingIdols = idols.filter(idol => idol.startDate >= today);
 
   useEffect(() => {
     if (value instanceof Date) {
@@ -55,6 +57,11 @@ function CalendarWrapper({ idols }: Props) {
       />
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
+          <NotificationInfoCardList filterDate={idol} />
+        </NotificationCard>
+      ))}
+      {upcomingIdols?.map(idol => (
+        <NotificationCard key={`upcoming-${idol.id}`}>
           <NotificationInfoCardList filterDate={idol} />
         </NotificationCard>
       ))}

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,0 +1,44 @@
+import { format } from 'date-fns';
+import { useState } from 'react';
+import Calendar, { TileArgs } from 'react-calendar';
+import { Idol } from '@store/idolStore';
+import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent.tsx';
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+type Props = {
+  idols: Idol[];
+};
+
+function CalendarWrapper({ idols }: Props) {
+  const [value, onChange] = useState<Value>(new Date());
+
+  const makeTileContent = ({ date }: TileArgs) => {
+    const titleDate = format(date, 'yyyy-MM-dd');
+    const filtered = idols.filter(item => item.startDate === titleDate);
+    const type = filtered.map(item => item.type);
+    return (
+      <div className="flex h-full flex-col">
+        <div className="mt-2 flex max-h-[100px] flex-col overflow-hidden">
+          {type.map(item => (
+            <CalendarTileContent filterIdols={item} key={item} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <article>
+      <Calendar
+        locale="ko"
+        value={value}
+        onChange={onChange}
+        tileContent={makeTileContent}
+      />
+    </article>
+  );
+}
+
+export default CalendarWrapper;

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,8 +1,10 @@
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Calendar, { TileArgs } from 'react-calendar';
+import NotificationCard from '@components/common/Card/NotificationCard';
+import NotificationInfoCardList from '@components/common/Card/NotificationInfoCardList';
 import { Idol } from '@store/idolStore';
-import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent.tsx';
+import CalendarTileContent from '@/components/common/Calendar/CalendarTileContent';
 
 type ValuePiece = Date | null;
 
@@ -13,6 +15,20 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | string | number>(
+    null
+  );
+  const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
+
+  useEffect(() => {
+    if (value instanceof Date) {
+      setSelectedDate(format(value, 'yyyy-MM-dd'));
+    } else if (Array.isArray(value)) {
+      setSelectedDate(format(value[0], 'yyyy-MM-dd'));
+    } else {
+      setSelectedDate(null);
+    }
+  }, [value]);
 
   const makeTileContent = ({ date }: TileArgs) => {
     const titleDate = format(date, 'yyyy-MM-dd');
@@ -37,6 +53,11 @@ function CalendarWrapper({ idols }: Props) {
         onChange={onChange}
         tileContent={makeTileContent}
       />
+      {selectedIdol?.map(idol => (
+        <NotificationCard key={idol.id}>
+          <NotificationInfoCardList filterDate={idol} />
+        </NotificationCard>
+      ))}
     </article>
   );
 }

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -55,11 +55,13 @@ function CalendarWrapper({ idols }: Props) {
         onChange={onChange}
         tileContent={makeTileContent}
       />
+      <h3 className="mt-12 text-2xl font-bold">오늘의 스케줄</h3>
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
           <NotificationInfoCardList filterDate={idol} />
         </NotificationCard>
       ))}
+      <h3 className="mt-12 text-2xl font-bold">다가오는 스케줄</h3>
       {upcomingIdols?.map(idol => (
         <NotificationCard key={`upcoming-${idol.id}`}>
           <NotificationInfoCardList filterDate={idol} />

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -15,9 +15,9 @@ type Props = {
 
 function CalendarWrapper({ idols }: Props) {
   const [value, onChange] = useState<Value>(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | string | number>(
-    null
-  );
+  const [selectedDate, setSelectedDate] = useState<
+    Date | string | null | number
+  >(null);
   const selectedIdol = idols.filter(idol => idol.startDate === selectedDate);
 
   useEffect(() => {
@@ -32,13 +32,13 @@ function CalendarWrapper({ idols }: Props) {
 
   const makeTileContent = ({ date }: TileArgs) => {
     const titleDate = format(date, 'yyyy-MM-dd');
-    const filtered = idols.filter(item => item.startDate === titleDate);
-    const type = filtered.map(item => item.type);
+    const filteredIdols = idols.filter(item => item.startDate === titleDate);
+    const types = filteredIdols.map(item => item.type);
     return (
       <div className="flex h-full flex-col">
         <div className="mt-2 flex max-h-[100px] flex-col overflow-hidden">
-          {type.map(item => (
-            <CalendarTileContent filterIdols={item} key={item} />
+          {types.map(type => (
+            <CalendarTileContent filterIdols={type} key={type} />
           ))}
         </div>
       </div>

--- a/src/components/common/Card/NotificationCard.tsx
+++ b/src/components/common/Card/NotificationCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function NotificationCard({ children }: Props) {
+  return (
+    <div className="mt-12 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
+      {children}
+    </div>
+  );
+}
+
+export default NotificationCard;

--- a/src/components/common/Card/NotificationCard.tsx
+++ b/src/components/common/Card/NotificationCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 function NotificationCard({ children }: Props) {
   return (
-    <div className="mt-12 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
+    <div className="mt-4 flex max-h-[300px] cursor-pointer flex-col rounded-xl p-4 shadow-lg">
       {children}
     </div>
   );

--- a/src/components/common/Card/NotificationInfoCardList.tsx
+++ b/src/components/common/Card/NotificationInfoCardList.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Arrow } from '@assets/icons/inedx.ts';
+import { Idol } from '@store/idolStore.ts';
+
+type Props = {
+  filterDate: Idol;
+};
+
+function NotificationInfoCardList({ filterDate }: Props) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-1">
+        <p className="text-lg font-bold">
+          {filterDate.type} & {filterDate.title}
+        </p>
+        <p className="truncate text-gray-500">{filterDate.description}</p>
+        <p className="text-gray-500">
+          {filterDate.location}: {filterDate.startDate} ~ {filterDate.endDate}
+        </p>
+      </div>
+      <div>
+        <Arrow />
+      </div>
+    </div>
+  );
+}
+
+export default NotificationInfoCardList;

--- a/src/components/common/IdolDropdownPanel.tsx
+++ b/src/components/common/IdolDropdownPanel.tsx
@@ -1,7 +1,18 @@
 import { Link } from 'react-router';
 
+type Idol = {
+  id: number;
+  idolId: number;
+  title: string;
+  type: string;
+  startDate: string;
+  endDate: string;
+  location: string;
+  description: string;
+};
+
 type Props = {
-  idols: { id: number; name: string }[];
+  idols: Idol[];
   selectedIdolId: number | null;
   setSelectIdol: (idolId: number) => void;
 };
@@ -18,7 +29,7 @@ function IdolDropdownPanel({ idols, selectedIdolId, setSelectIdol }: Props) {
               selectedIdolId === idol.id && 'bg-gray-100'
             }`}
           >
-            {idol.name}
+            {idol.title}
           </button>
         </div>
       ))}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,8 +20,8 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full bg-white">
-      <div className="mx-auto flex max-w-[1080px] items-center justify-between p-4">
+    <header className="fixed z-[9999] w-full max-w-[1080px] bg-red-200">
+      <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">
             <h1 className="pb-2 text-3xl leading-none font-bold">Wistar</h1>
@@ -30,7 +30,7 @@ function Header() {
           <Dropdown
             isDropdownOpen={isDropdownOpen}
             handleOnToggle={handleOnToggle}
-            selectedIdol={selectedIdol?.name ?? '아이돌 선택'}
+            selectedIdol={selectedIdol?.title ?? '아이돌 선택'}
           >
             <IdolDropdownPanel
               idols={idols}
@@ -49,7 +49,7 @@ function Header() {
             ))}
           </nav>
         ) : (
-          <div>
+          <div className="ml-auto">
             <button
               type="button"
               onClick={() => setIsOpen(prev => !prev)}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,7 +20,7 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full max-w-[1080px] bg-red-200">
+    <header className="fixed z-[9999] w-full max-w-[1080px]">
       <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -20,7 +20,7 @@ function Header() {
   };
 
   return (
-    <header className="fixed z-[9999] w-full max-w-[1080px]">
+    <header className="fixed z-[9999] w-full max-w-[1080px] bg-white">
       <div className="flex items-center p-4">
         <div className="flex items-center gap-4">
           <Link to="/">

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -6,7 +6,9 @@ function Layout() {
   return (
     <div>
       <Header />
-      <Outlet />
+      <main className="py-8">
+        <Outlet />
+      </main>
       <Footer />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,77 @@
 @import "tailwindcss";
 
 @layer base {
-    root {
+    html,body {
         @apply max-w-[1080px] mx-auto;
+    }
+}
+
+@layer components {
+    /* 전체 캘린더 박스 */
+    .react-calendar {
+        @apply flex flex-col items-center text-center  max-h-[600px] border border-gray-200 p-4 shadow-md;
+    }
+
+    /* navigation 영역 (월/연 이동) */
+    .react-calendar__navigation {
+        @apply flex justify-between items-center w-full text-lg mb-4;
+    }
+
+    /* navigation 버튼 공통 스타일 */
+    .react-calendar__navigation button {
+        @apply cursor-pointer px-4;
+    }
+
+    /* navigation - prev, next 버튼 */
+    .react-calendar__navigation__prev-button,
+    .react-calendar__navigation__next-button {
+        @apply px-4;
+    }
+
+    /* navigation - prev2, next2 버튼 숨기기 (10년 이동 버튼) */
+    .react-calendar__navigation__prev2-button,
+    .react-calendar__navigation__next2-button {
+        @apply hidden;
+    }
+
+    /* navigation label 텍스트 정리 */
+    .react-calendar__navigation__label {
+        @apply mx-4;
+    }
+
+    /* 요일(일,월,화,수) 줄 */
+    .react-calendar__month-view__weekdays {
+        @apply flex justify-center max-h-[200px];
+    }
+
+    /* 요일(일,월,화,수) 글자 */
+    .react-calendar__month-view__weekdays__weekday {
+        @apply text-center text-lg mt-4;
+    }
+
+    /* 요일 글자 데코 제거 (밑줄 없애기) */
+    .react-calendar__month-view__weekdays__weekday abbr {
+        text-decoration: none;
+    }
+
+    /* 오늘 날짜 강조 */
+    .react-calendar__tile--now {
+        @apply font-bold bg-red-500 text-white;
+    }
+
+    /* 오늘 날짜 클릭했을 때, hover했을 때 */
+    .react-calendar__tile--now:active,
+    .react-calendar__tile--now:hover {
+        @apply bg-black text-white;
+    }
+
+    /* 활성화된(선택된) 날짜 */
+    .react-calendar__tile--active {
+        @apply bg-black text-white;
+    }
+
+    /* 날짜 타일 스타일 */
+    .react-calendar__month-view__days__day {
+        @apply mt-4 py-2 rounded-md hover:bg-red-200 transition;
     }
 }

--- a/src/pages/schedule/Schedule.tsx
+++ b/src/pages/schedule/Schedule.tsx
@@ -1,5 +1,29 @@
+import { useIdolState } from '@store/idolStore';
+import CalendarWrapper from '@/components/common/Calendar/CalendarWrapper';
+
 function Schedule() {
-  return <div>Schedule</div>;
+  const { idols } = useIdolState();
+  const isLogin = true;
+
+  const publicIdols = [
+    {
+      id: 99,
+      idolId: 99,
+      title: 'K-POP 축제',
+      type: '공연',
+      startDate: '2025-05-25',
+      endDate: '2025-05-25',
+      location: '서울 월드컵 경기장',
+      description: 'K-POP 슈퍼 콘서트',
+    },
+  ];
+
+  const displayIdols = isLogin ? idols : publicIdols;
+  return (
+    <section className="mt-20 px-2">
+      <CalendarWrapper idols={displayIdols} />
+    </section>
+  );
 }
 
 export default Schedule;

--- a/src/store/idolStore.ts
+++ b/src/store/idolStore.ts
@@ -1,22 +1,62 @@
 import { create } from 'zustand/react';
 
+export type Idol = {
+  id: number;
+  idolId: number;
+  title: string;
+  type: string;
+  startDate: string;
+  endDate: string;
+  location: string;
+  description: string;
+};
+
 interface IdolState {
-  idols: { id: number; name: string }[];
+  idols: Idol[];
   selectedIdolId: number | null;
   setSelectIdol: (idolId: number) => void;
-  addIdol: (idol: { id: number; name: string }) => void;
+  addIdol: (idol: Idol) => void;
   removeIdol: (idolId: number) => void;
 }
 
+const idols: Idol[] = [
+  {
+    id: 1,
+    idolId: 1,
+    title: '트와이스 팬미팅',
+    type: '팬미팅',
+    startDate: '2025-05-03',
+    endDate: '2025-05-03',
+    location: '서울 올림픽홀',
+    description: '2025년 상반기 팬미팅',
+  },
+  {
+    id: 2,
+    idolId: 1,
+    title: '트와이스 콘서트',
+    type: '공연',
+    startDate: '2025-05-10',
+    endDate: '2025-05-10',
+    location: '부산 벡스코',
+    description: 'TWICE WORLD TOUR 2025',
+  },
+  {
+    id: 3,
+    idolId: 1,
+    title: '음방 출연 - 음악중심',
+    type: '방송',
+    startDate: '2025-05-18',
+    endDate: '2025-05-18',
+    location: 'MBC 상암동',
+    description: '음악중심 생방송 출연',
+  },
+];
+
 export const useIdolState = create<IdolState>(set => ({
-  idols: [
-    { id: 1, name: '트와이스' },
-    { id: 2, name: '레드벨벳' },
-    { id: 3, name: 'IVE' },
-  ],
+  idols,
   selectedIdolId: null,
   setSelectIdol: (id: number) => set({ selectedIdolId: id }),
-  addIdol: (idol: { id: number; name: string }) =>
+  addIdol: (idol: Idol) =>
     set(state => ({ idols: [...state.idols, { ...idol }] })),
   removeIdol: (idolId: number) =>
     set(state => ({ idols: state.idols.filter(id => id.id !== idolId) })),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
close #14 
## 📝작업 내용
- 스케줄 페이지(CalendarWrapper) 기본 구조 구현
- 오늘의 스케줄 / 다가오는 스케줄 구분하여 표시
- NotificationCard, NotificationInfoCardList 컴포넌트 분리 및 적용
- Header 컴포넌트 배경색(bg-white) 추가하여 스크롤 이슈 해결
- 다가오는 일정(upcoming schedule) 자동 표시 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 전체적인 스케줄 페이지 흐름 및 컴포넌트 분리 구조가 자연스러운지 확인 부탁드립니다.

