### PR TITLE
:sparkles: feat: #33 /schedule/:id 라우터 및 상세 페이지 UI 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router';
+import ScheduleDetail from '@pages/schedule/ScheduleDetail';
 import Layout from '@/components/layouts/Layout';
 import Artist from '@/pages/artists/Artist';
 import Home from '@/pages/home/Home';
@@ -24,6 +25,10 @@ function App() {
         {
           path: '/schedule',
           element: <Schedule />,
+        },
+        {
+          path: '/schedule/:id',
+          element: <ScheduleDetail />,
         },
         {
           path: '/timeline',

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,6 +1,8 @@
 import { format } from 'date-fns';
 import { useEffect, useState } from 'react';
 import Calendar, { TileArgs } from 'react-calendar';
+
+import { Link } from 'react-router';
 import NotificationCard from '@components/common/Card/NotificationCard';
 import NotificationInfoCardList from '@components/common/Card/NotificationInfoCardList';
 import { Idol } from '@store/idolStore';
@@ -58,13 +60,17 @@ function CalendarWrapper({ idols }: Props) {
       <h3 className="mt-12 text-2xl font-bold">선택한 스케줄</h3>
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
-          <NotificationInfoCardList filterDate={idol} />
+          <Link to={idol.id.toString()}>
+            <NotificationInfoCardList filterDate={idol} />
+          </Link>
         </NotificationCard>
       ))}
       <h3 className="mt-12 text-2xl font-bold">다가오는 스케줄</h3>
       {upcomingIdols?.map(idol => (
         <NotificationCard key={`upcoming-${idol.id}`}>
-          <NotificationInfoCardList filterDate={idol} />
+          <Link to={idol.id.toString()}>
+            <NotificationInfoCardList filterDate={idol} />
+          </Link>
         </NotificationCard>
       ))}
     </article>

--- a/src/pages/schedule/ScheduleDetail.tsx
+++ b/src/pages/schedule/ScheduleDetail.tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router';
+
+const IDOL_DETAIL = ['#보이넥스트도어', '#보이넥스트도어'];
+
+function ScheduleDetail() {
+  const { id } = useParams();
+
+  if (!id) return <div className="p-4">잘못된 접근입니다.</div>;
+
+  return (
+    <section className="mt-24 p-4">
+      <article>
+        {id}
+        <h1 className="mb-20 text-xl font-bold">
+          [🐦] BOYNEXTDOOR 4th EP [No Genre] 예약 구매자 대상 영상통화 팬사인회
+          안내
+          <a
+            href="https://t.co/BV0WXb4cum"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            🔗 https://t.co/BV0WXb4cum
+          </a>
+          #BOYNEXTDOOR #보이넥스트도어 #BND #No_Genre
+        </h1>
+        <div className="flex h-[300px] max-h-[400px] items-center rounded-md border border-gray-200 p-8">
+          <p>lorem ipsum</p>
+        </div>
+        <ul className="mt-12 flex items-center gap-4">
+          {IDOL_DETAIL.map(idol => (
+            <li
+              key={idol}
+              className="rounded-2xl border border-gray-200 p-2 text-sm font-bold"
+            >
+              {idol}
+            </li>
+          ))}
+        </ul>
+      </article>
+    </section>
+  );
+}
+
+export default ScheduleDetail;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #33

## 📝 작업 내용

- /schedule/:id 라우팅 추가 및 상세 페이지 구성
- useParams로 id 받아서 상세 페이지 렌더링
- 일정 제목, 내용, 링크, 아이돌 해시태그 등 기본 UI 마크업 구성

### 스크린샷 (선택)


## 💬 리뷰 요구사항 (선택)

- 상세 UI 구조 및 마크업 네이밍이 적절한지 봐주시면 감사하겠습니다.
- 외부 링크 처리 방식(`<a>` 처리)나 해시태그 리스트 구성 방식도 리뷰해주시면 좋겠습니다.
