### PR TITLE
✨ Feature/#33 schedule detail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router';
+import ScheduleDetail from '@pages/schedule/ScheduleDetail';
 import Layout from '@/components/layouts/Layout';
 import Artist from '@/pages/artists/Artist';
 import Home from '@/pages/home/Home';
@@ -24,6 +25,10 @@ function App() {
         {
           path: '/schedule',
           element: <Schedule />,
+        },
+        {
+          path: '/schedule/:id',
+          element: <ScheduleDetail />,
         },
         {
           path: '/timeline',

--- a/src/components/common/Calendar/CalendarWrapper.tsx
+++ b/src/components/common/Calendar/CalendarWrapper.tsx
@@ -1,6 +1,8 @@
 import { format } from 'date-fns';
 import { useEffect, useState } from 'react';
 import Calendar, { TileArgs } from 'react-calendar';
+
+import { Link } from 'react-router';
 import NotificationCard from '@components/common/Card/NotificationCard';
 import NotificationInfoCardList from '@components/common/Card/NotificationInfoCardList';
 import { Idol } from '@store/idolStore';
@@ -58,13 +60,17 @@ function CalendarWrapper({ idols }: Props) {
       <h3 className="mt-12 text-2xl font-bold">선택한 스케줄</h3>
       {selectedIdol?.map(idol => (
         <NotificationCard key={idol.id}>
-          <NotificationInfoCardList filterDate={idol} />
+          <Link to={idol.id.toString()}>
+            <NotificationInfoCardList filterDate={idol} />
+          </Link>
         </NotificationCard>
       ))}
       <h3 className="mt-12 text-2xl font-bold">다가오는 스케줄</h3>
       {upcomingIdols?.map(idol => (
         <NotificationCard key={`upcoming-${idol.id}`}>
-          <NotificationInfoCardList filterDate={idol} />
+          <Link to={idol.id.toString()}>
+            <NotificationInfoCardList filterDate={idol} />
+          </Link>
         </NotificationCard>
       ))}
     </article>

--- a/src/pages/schedule/ScheduleDetail.tsx
+++ b/src/pages/schedule/ScheduleDetail.tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router';
+
+const IDOL_DETAIL = ['#보이넥스트도어', '#보이넥스트도어'];
+
+function ScheduleDetail() {
+  const { id } = useParams();
+
+  if (!id) return <div className="p-4">잘못된 접근입니다.</div>;
+
+  return (
+    <section className="mt-24 p-4">
+      <article>
+        {id}
+        <h1 className="mb-20 text-xl font-bold">
+          [🐦] BOYNEXTDOOR 4th EP [No Genre] 예약 구매자 대상 영상통화 팬사인회
+          안내
+          <a
+            href="https://t.co/BV0WXb4cum"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            🔗 https://t.co/BV0WXb4cum
+          </a>
+          #BOYNEXTDOOR #보이넥스트도어 #BND #No_Genre
+        </h1>
+        <div className="flex h-[300px] max-h-[400px] items-center rounded-md border border-gray-200 p-8">
+          <p>lorem ipsum</p>
+        </div>
+        <ul className="mt-12 flex items-center gap-4">
+          {IDOL_DETAIL.map(idol => (
+            <li
+              key={idol}
+              className="rounded-2xl border border-gray-200 p-2 text-sm font-bold"
+            >
+              {idol}
+            </li>
+          ))}
+        </ul>
+      </article>
+    </section>
+  );
+}
+
+export default ScheduleDetail;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #33

## 📝 작업 내용

- 일정 상세 페이지 라우팅(`/schedule/:id`) 추가
- 상세 페이지 UI 마크업 및 기본 구조 구현
- 아이돌 해시태그 렌더링 및 외부 링크 구성 포함
- feature/#33-schedule_detail_ui 파생 브랜치 머지 완료

### 스크린샷 (선택)

(생략 가능)

## 💬 리뷰 요구사항 (선택)

- 전체 마크업 구조 및 네이밍 일관성이 유지되고 있는지 확인 부탁드립니다.
- 추후 API 연동을 고려했을 때 지금 구조가 유연한지도 피드백 부탁드립니다.
