### PR TITLE
✨ feat: 화면에 페이지 경로 표시 기능 추가

### DIFF
--- a/src/components/common/Breadcrumb.tsx
+++ b/src/components/common/Breadcrumb.tsx
@@ -1,0 +1,25 @@
+import { Link, useLocation } from 'react-router';
+
+function Breadcrumb() {
+  const location = useLocation();
+  const paths = location.pathname.split('/').filter(Boolean);
+  return (
+    <div className="mt-10 ml-5 text-gray-500">
+      {location.pathname === '/' ? null : (
+        <div>
+          <Link to="/">Home</Link>
+          {paths.map((segment, idx) => (
+            // schedule로 예를 들면 slice 메서드를 사용하여 0번째 인덱스 즉 schedule이 되고 idx+1는 아이돌 아이디를 가리킴
+            <Link to={`/${paths.slice(0, idx + 1).join('/')}`}>
+              <span key={location.key}>
+                {' '}
+                {'>'} {segment}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+export default Breadcrumb;

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,12 +1,14 @@
 import { Outlet } from 'react-router';
 import Footer from './Footer';
 import Header from './Header/Header';
+import Breadcrumb from '../common/Breadcrumb';
 
 function Layout() {
   return (
     <div>
       <Header />
       <main className="py-8">
+        <Breadcrumb />
         <Outlet />
       </main>
       <Footer />


### PR DESCRIPTION
## #️⃣연관된 이슈

close #42

## 📝작업 내용

> Breadcrumb 컴포넌트를 구현했습니다.

- `useLocation()`을 이용해 현재 경로를 추출하고, 이를 기반으로 경로 분할 처리
- 경로 조각을 누적하여 `/artists`, `/artists/2` 형식으로 변환해 중간 경로는 `<Link>`로 이동 가능하게 처리
- 마지막 segment는 현재 페이지를 의미하므로 링크 없이 텍스트만 표시되도록 처리
- `Home`은 항상 가장 앞에 고정되어 표시됩니다

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a1098011-d905-43f1-85ed-1f678dd3d813)


## 💬리뷰 요구사항(선택)
