### PR TITLE
Feature/#72 artist create

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Timeline from '@/pages/timeline/Timeline';
 import TimelineDetail from '@/pages/timeline/TimelineDetail';
 import TimelineEdit from '@/pages/timeline/TimelineEdit';
 import TimelineWrite from '@/pages/timeline/TimelineWrite';
+import CreateArtist from './pages/artists/CreateArtist';
 
 
 function App() {
@@ -75,6 +76,10 @@ function App() {
 path: '/editprofile',
 element: <EditProfile />,
         },
+        {
+          path: '/artists/create',
+          element: <CreateArtist />,
+        }
       ],
     },
   ]);

--- a/src/pages/artists/Artist.tsx
+++ b/src/pages/artists/Artist.tsx
@@ -53,32 +53,6 @@ function Artist() {
     fetchIdolList();
   }, []);
 
-  // 아이돌 생성
-  const handleAddIdol = async () => {
-    try {
-      const res = await axios.post('/api/idols/', {
-        name: '트와이스',
-        debut_date: '2015-10-20',
-        agency: 'JYP',
-        description: 'K-pop girl group',
-        profile_image: 'https://example.com/images/twice.jpg',
-        is_active: true,
-      });
-      const newIdol = {
-        id: res.data.data.idol_id,
-        name: res.data.data.name,
-        img: res.data.data.profile_image,
-        isVertical: false,
-      };
-      setIdolList(prev => [...prev, newIdol]);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    }
-    // eslint-disable-next-line no-console
-    console.log('추가 후 아이돌 리스트', idolList);
-  };
-
   // 팔로우 아이돌 api 요청
   useEffect(() => {
     async function fetchFollowIdols() {
@@ -140,7 +114,7 @@ function Artist() {
 
   return (
     <div>
-      <button onClick={handleAddIdol} type="button">
+      <button onClick={() => navigate('/artists/create')} type='button'>
         추가
       </button>
       <div className="mx-auto max-w-[1080px]">

--- a/src/pages/artists/CreateArtist.tsx
+++ b/src/pages/artists/CreateArtist.tsx
@@ -1,0 +1,114 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/store/authStore';
+
+// 아이돌 생성에 필요한 데이터 타입
+interface IdolData {
+  name: string;
+  debut_date: string;
+  agency: string;
+  description: string;
+  profile_image: string;
+  is_active: boolean;
+};
+function CreateArtist() {
+  const { accessToken } = useAuthStore.getState();
+  const navigate = useNavigate();
+
+  // 폼에서 입력되는 아이돌 정보 상태
+  const [formIdolData, setFormIdolData] = useState<IdolData>({
+    name: '',
+    debut_date: '',
+    agency: '',
+    description: '',
+    profile_image: '',
+    is_active: true,
+  });
+
+  const handleAddIdol = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault(); // 새로고침 방지
+    try {
+      const res = await axios.post('/api/idols/',formIdolData ,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        }
+        });
+      
+      // 응답 받은 데이터를 상태에 반영
+      setFormIdolData({
+        name: res.data.name,
+        debut_date: res.data.debut_date,
+        agency: res.data.agency,
+        description: res.data.description,
+        profile_image: res.data.profile_image,
+        is_active: res.data.is_active,
+      });
+      
+      navigate('/');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-white'>
+      <form onSubmit={handleAddIdol} className='w-full max-w-md p-8 space-y-4'>
+        <div className='block text-md font-medium text-gray-700'>이름</div>
+        <input
+          className='w-full rounded-md border border-gray-300 px-3 py-2 text-sm'
+          id='name'
+          type="text"
+          value={formIdolData.name}
+          onChange={e => setFormIdolData(prev => ({ ...prev, name: e.target.value }))}
+        />
+
+        <div className='block text-md font-medium text-gray-700'>데뷔일</div>
+        <input
+          id='debut_date'
+          type="date"
+          value={formIdolData.debut_date}
+          onChange={e => setFormIdolData(prev => ({ ...prev, debut_date: e.target.value }))}
+          className='w-full border border-gray-300 px-3 py-2 text-sm rounded'
+        />
+
+        <div className='block text-md font-medium text-gray-700'>소속사</div>
+        <input
+          id='agency'
+          type="text"
+          value={formIdolData.agency}
+          onChange={e => setFormIdolData(prev => ({ ...prev, agency: e.target.value }))}
+          className='w-full rounded border border-gray-300 px-3 py-2 text-sm'
+        />
+
+        <div className='block text-md font-medium text-gray-700'>소개</div>
+        <textarea
+          id='description'
+          value={formIdolData.description}
+          onChange={e => setFormIdolData(prev => ({ ...prev, description: e.target.value }))}
+          className='w-full border border-gray-300 px-3 py-2 text-sm'
+        />
+
+
+        <input
+          id='profile_image'
+          type="url"
+          value={formIdolData.profile_image}
+          onChange={e => setFormIdolData(prev => ({ ...prev, profile_image: e.target.value }))}
+          className='border w-30 border-gray-300 text-sm'
+        />
+
+        <div className='mt-6 flex justify-center'>
+          <button
+            type="submit"
+            className='w-full font-semibold py-2 rounded bg-black text-white hover:bggray800 text-sm'>
+            아티스트 등록
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default CreateArtist;

--- a/src/pages/artists/CreateArtist.tsx
+++ b/src/pages/artists/CreateArtist.tsx
@@ -54,59 +54,62 @@ function CreateArtist() {
   };
   return (
     <div className='flex min-h-screen items-center justify-center bg-white'>
-      <form onSubmit={handleAddIdol} className='w-full max-w-md p-8 space-y-4'>
-        <div className='block text-md font-medium text-gray-700'>이름</div>
-        <input
-          className='w-full rounded-md border border-gray-300 px-3 py-2 text-sm'
-          id='name'
-          type="text"
-          value={formIdolData.name}
-          onChange={e => setFormIdolData(prev => ({ ...prev, name: e.target.value }))}
-        />
+      <div>  
+        <h2 className="mb-2 text-center text-2xl font-bold">Idol 추가</h2>
+        <form onSubmit={handleAddIdol} className='w-full max-w-md p-8 space-y-4'>
+          <div className='block text-md font-medium text-gray-700'>이름</div>
+          <input
+            className='w-full rounded-md border border-gray-300 px-3 py-2 text-sm'
+            id='name'
+            type="text"
+            value={formIdolData.name}
+            onChange={e => setFormIdolData(prev => ({ ...prev, name: e.target.value }))}
+            />
 
-        <div className='block text-md font-medium text-gray-700'>데뷔일</div>
-        <input
-          id='debut_date'
-          type="date"
-          value={formIdolData.debut_date}
-          onChange={e => setFormIdolData(prev => ({ ...prev, debut_date: e.target.value }))}
-          className='w-full border border-gray-300 px-3 py-2 text-sm rounded'
-        />
+          <div className='block text-md font-medium text-gray-700'>데뷔일</div>
+          <input
+            id='debut_date'
+            type="date"
+            value={formIdolData.debut_date}
+            onChange={e => setFormIdolData(prev => ({ ...prev, debut_date: e.target.value }))}
+            className='w-full border border-gray-300 px-3 py-2 text-sm rounded'
+            />
 
-        <div className='block text-md font-medium text-gray-700'>소속사</div>
-        <input
-          id='agency'
-          type="text"
-          value={formIdolData.agency}
-          onChange={e => setFormIdolData(prev => ({ ...prev, agency: e.target.value }))}
-          className='w-full rounded border border-gray-300 px-3 py-2 text-sm'
-        />
+          <div className='block text-md font-medium text-gray-700'>소속사</div>
+          <input
+            id='agency'
+            type="text"
+            value={formIdolData.agency}
+            onChange={e => setFormIdolData(prev => ({ ...prev, agency: e.target.value }))}
+            className='w-full rounded border border-gray-300 px-3 py-2 text-sm'
+            />
 
-        <div className='block text-md font-medium text-gray-700'>소개</div>
-        <textarea
-          id='description'
-          value={formIdolData.description}
-          onChange={e => setFormIdolData(prev => ({ ...prev, description: e.target.value }))}
-          className='w-full border border-gray-300 px-3 py-2 text-sm'
-        />
+          <div className='block text-md font-medium text-gray-700'>소개</div>
+          <textarea
+            id='description'
+            value={formIdolData.description}
+            onChange={e => setFormIdolData(prev => ({ ...prev, description: e.target.value }))}
+            className='w-full border border-gray-300 px-3 py-2 text-sm'
+            />
 
 
-        <input
-          id='profile_image'
-          type="url"
-          value={formIdolData.profile_image}
-          onChange={e => setFormIdolData(prev => ({ ...prev, profile_image: e.target.value }))}
-          className='border w-30 border-gray-300 text-sm'
-        />
+          <input
+            id='profile_image'
+            type="url"
+            value={formIdolData.profile_image}
+            onChange={e => setFormIdolData(prev => ({ ...prev, profile_image: e.target.value }))}
+            className='border w-30 border-gray-300 text-sm'
+            />
 
-        <div className='mt-6 flex justify-center'>
-          <button
-            type="submit"
-            className='w-full font-semibold py-2 rounded bg-black text-white hover:bggray800 text-sm'>
-            아티스트 등록
-          </button>
-        </div>
-      </form>
+          <div className='mt-6 flex justify-center'>
+            <button
+              type="submit"
+              className='w-full font-semibold py-2 rounded bg-black text-white hover:bggray800 text-sm'>
+              아티스트 등록
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #72 

## 📝작업 내용

> /artist/create 라우트 및 페이지 파일 생성
> CreateArtist 폼 컴포넌트 구현
> 입력 항목: 이름, 데뷔일, 소속사, 설명, 프로필 이미지 URL, 활동 여부
> 아티스트 등록 시 POST /api/idols/ API 호출 및 토큰 인증 처리
> 등록 성공 시 /artist 페이지로 리다이렉트 및 전체 아티스트 목록 반영
> Artist 페이지 내 “아티스트 추가” 버튼에 navigate('/artist/create') 연동

### 스크린샷 (선택)
<img width="698" alt="image" src="https://github.com/user-attachments/assets/86b2788b-e740-4d22-a73c-8ac7f3a52ce1" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/f68a732c-f4f0-4253-ac96-60d68b550f64" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
