### PR TITLE
:sparkles: feature: #83 Timeline 상세 페이지 댓글 삭제 기능 구현 (soft, hard delete)

### DIFF
--- a/src/hooks/useComments.tsx
+++ b/src/hooks/useComments.tsx
@@ -17,7 +17,6 @@ function useComments() {
     const {parentComments, childCommentMap} = useMemo(() => {
         const parent = [];
         const childMap: Record<string, UserComment[]> = {};
-
         comments.forEach(comment => {
             if (comment.parent_id == null) {
                 parent.push(comment);
@@ -34,6 +33,7 @@ function useComments() {
 
     return {
         parentComments,
+        comments,
         setComments,
         childCommentMap,
         inputMode,

--- a/src/pages/timeline/CommentItem.tsx
+++ b/src/pages/timeline/CommentItem.tsx
@@ -14,6 +14,7 @@ type Props = {
         handleEditComment: () => void;
         handleAddReplyComment: () => void;
         handleDeleteComment: (comment_id: number) => void;
+        handleAllDeleteComment: (comment_id: number) => void;
     }
 };
 
@@ -148,19 +149,32 @@ function CommentItem({
                             삭제
                         </button>
                     </div>
+                    {
+                        !item.parent_id &&
+                        <div>
+                            <button
+                                type="button"
+                                className="block w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-50"
+                                onClick={() => commentService.handleAllDeleteComment(item.comment_id)}
+                            >
+                                전체 삭제
+                            </button>
+                        </div>
+                    }
                 </Dropdown>
             </div>
-            <ul className="mt-4 space-y-4">
-                {childComments.map(replyComment =>
-                    <CommentItem
-                        key={replyComment.comment_id}
-                        item={replyComment}
-                        childCommentMap={childCommentMap}
-                        inputMode={inputMode}
-                        setInputMode={setInputMode}
-                        commentService={commentService}
-                    />
-                )
+            <ul className="mt-4 space-y-4 pl-4">
+                {childComments.length > 0 &&
+                    childComments.map(replyComment =>
+                        <CommentItem
+                            key={replyComment.comment_id}
+                            item={replyComment}
+                            childCommentMap={childCommentMap}
+                            inputMode={inputMode}
+                            setInputMode={setInputMode}
+                            commentService={commentService}
+                        />
+                    )
                 }
             </ul>
         </li>

--- a/src/pages/timeline/TimelineDetail.tsx
+++ b/src/pages/timeline/TimelineDetail.tsx
@@ -15,6 +15,7 @@ function TimelineDetail() {
     const {
         inputMode,
         setInputMode,
+        comments,
         setComments,
         parentComments,
         childCommentMap,
@@ -49,8 +50,17 @@ function TimelineDetail() {
     }, [inputMode, setComments, setInputMode]);
 
     const handleDeleteComment = useCallback((comment_id: number) => {
-        setComments((prev) => (prev.filter(item => item.comment_id !== comment_id)));
-    }, [setComments]);
+        const find = comments.find(item => item.comment_id === comment_id);
+        const parent = find.parent_id;
+        setComments((prev) => prev.map(item => item.parent_id === comment_id ? {
+            ...item,
+            parent_id: parent,
+        } : item).filter(v => v.comment_id !== comment_id));
+    }, [setComments, comments]);
+
+    const handleAllDeleteComment = (comment_id: number) => {
+        setComments((prev) => prev.filter(item => item.comment_id !== comment_id));
+    };
 
     const handleAddRootComment = () => {
         setRootInput('');
@@ -68,6 +78,7 @@ function TimelineDetail() {
         handleEditComment,
         handleAddReplyComment,
         handleDeleteComment,
+        handleAllDeleteComment
     };
 
     return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #83 

## 📝작업 내용

- 댓글 삭제 시 자식 댓글을 부모로 재귀적으로 변경하는 soft delete와
- 전체 삭제를 위한 hard delete 기능을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
