### PR TITLE
✨ feature/#83-timeline-comment_delete

### DIFF
--- a/src/hooks/useComments.tsx
+++ b/src/hooks/useComments.tsx
@@ -30,7 +30,6 @@ function useComments() {
         return {parentComments: parent, childCommentMap: childMap};
     }, [comments]);
 
-
     return {
         parentComments,
         comments,

--- a/src/pages/timeline/CommentItem.tsx
+++ b/src/pages/timeline/CommentItem.tsx
@@ -140,15 +140,18 @@ function CommentItem({
                             수정
                         </button>
                     </div>
-                    <div>
-                        <button
-                            type="button"
-                            className="block w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-50"
-                            onClick={() => commentService.handleDeleteComment(item.comment_id)}
-                        >
-                            삭제
-                        </button>
-                    </div>
+                    {
+                        item.parent_id &&
+                        <div>
+                            <button
+                                type="button"
+                                className="block w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-50"
+                                onClick={() => commentService.handleDeleteComment(item.comment_id)}
+                            >
+                                삭제
+                            </button>
+                        </div>
+                    }
                     {
                         !item.parent_id &&
                         <div>

--- a/src/pages/timeline/TimelineDetail.tsx
+++ b/src/pages/timeline/TimelineDetail.tsx
@@ -40,7 +40,7 @@ function TimelineDetail() {
         const newReply = {
             comment_id: Number(new Date()),
             content: inputMode.payload.value,
-            author: 'dndndn',
+            author: 'dndndㄻㅇㄴㄹㄴㅇn',
             createdAt: new Date().toISOString(),
             parent_id: inputMode.payload.parent_id,
             img: '../src/assets/img/ncity.jpeg'


### PR DESCRIPTION
#️⃣연관된 이슈
close https://github.com/09-MainProject/MyFavIdolFront/issues/83

📝작업 내용
댓글 삭제 시 자식 댓글을 부모로 재귀적으로 변경하는 soft delete와
전체 삭제를 위한 hard delete 기능을 추가했습니다.
스크린샷 (선택)
💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?