### PR TITLE
✨ feat: #101 팔로우 기능 추가 및 드롭다운 -> 스케줄 페이지 이동 기능 추가

### DIFF
--- a/src/components/common/Card/IdolCardList.tsx
+++ b/src/components/common/Card/IdolCardList.tsx
@@ -6,16 +6,16 @@ type PageType = 'artist' | 'home';
 
 export interface IdolArtistsCard {
   id: number;
-  // idolId: number;
+  idolId: number;
   title: string;
   img: string;
-  // type: string;
+  type: string;
   startDate: string;
-  // endDate: string;
-  // location: string;
-  // description: string;
+  endDate: string;
+  location: string;
+  description: string;
   name: string;
-  // enName: string;
+  enName: string;
 }
 
 type Props = {

--- a/src/components/common/Card/IdolCardList.tsx
+++ b/src/components/common/Card/IdolCardList.tsx
@@ -6,10 +6,16 @@ type PageType = 'artist' | 'home';
 
 export interface IdolArtistsCard {
   id: number;
-  name: string;
+  // idolId: number;
+  title: string;
   img: string;
-  title?: string;
-  startDate?: string;
+  // type: string;
+  startDate: string;
+  // endDate: string;
+  // location: string;
+  // description: string;
+  name: string;
+  // enName: string;
 }
 
 type Props = {

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -15,8 +15,8 @@ import {useIdolState} from '@store/idolStore';
 const DEFAULT_SELECTED_IDOL = '아이돌 선택';
 
 function Header() {
-    const idols = [];
-    const {selectedIdolId, setSelectIdol} = useIdolState();
+    const {followedIdols, selectedIdolId, setSelectIdol} = useIdolState();
+    const idols = followedIdols;
     const mobileRef = useRef<null | HTMLDivElement>(null);
     const navigate = useNavigate();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -74,7 +74,8 @@ function Header() {
                 <IdolDropdown handleToggleDropdown={handleToggleDropdown} idols={idols}
                               setSelectIdol={setSelectIdol} handleCloseDropdown={handleCloseDropdown}
                               dropdownOpen={dropdownOpen} selectedIdolId={selectedIdolId}
-                              displayedIdolName={displayedIdolName}/>
+                              displayedIdolName={displayedIdolName}
+                              />
                 {isMobile ? (
                     <>
                         <UserInfo

--- a/src/components/layouts/Header/IdolDropdown.tsx
+++ b/src/components/layouts/Header/IdolDropdown.tsx
@@ -21,7 +21,8 @@ function IdolDropdown({
                           displayedIdolName,
                           setSelectIdol,
                           selectedIdolId,
-                          handleCloseDropdown
+                          handleCloseDropdown,
+                          
                       }: Props) {
     return (
         <div className="relative flex items-center gap-4">
@@ -39,6 +40,7 @@ function IdolDropdown({
                     selectedIdolId={selectedIdolId}
                     setSelectIdol={setSelectIdol}
                     handleCloseDropdown={handleCloseDropdown}
+                    handleToggleDropdown={handleToggleDropdown}
                 />
             </Dropdown>
         </div>

--- a/src/pages/artists/Artist.tsx
+++ b/src/pages/artists/Artist.tsx
@@ -19,8 +19,7 @@ function Artist() {
   const [idolList, setIdolList] = useState<Idol[]>([]);
   // 팔로우 아이돌 리스트 상태
   const [followIdols, setFollowIdols] = useState<IdolArtistsCard[]>([]);
-  // 아이돌 생성
-  // const [newIdol, setNewIdol] = useState<Idol[]>([]);
+  const { setFollowedIdols } = useIdolState();
   
   // 전체 아이돌 리스트 api 요청
   useEffect(() => {
@@ -56,17 +55,28 @@ function Artist() {
   // 팔로우 아이돌 api 요청
   useEffect(() => {
     async function fetchFollowIdols() {
-      // try {
-      //   const resFollow = await axios.get(
-      //     'http://43.203.181.6/api/idols/follows_idols/'
-      //   );
-      //   setFollowIdols(resFollow.data.followed_idols);
-      // } catch (error) {
-      //   console.error(error);
-      // }
+      if (idolList.length === 0) return;
+
+      try {
+        const resFollow = await api.get(
+          '/idols/follows'
+        );
+        const followed = resFollow.data.map(item => {
+          const matchedIdol = idolList.find(idol => idol.id === item.idol.id);
+          return {
+            id: item.idol.id,
+            name: item.idol.name,
+            img: matchedIdol?.img ?? '',
+          };
+        });
+        setFollowIdols(followed); // 로컬 상태
+        setFollowedIdols(followed); // 전역 상태
+      } catch (error) {
+        console.error(error);
+      }
     }
     fetchFollowIdols();
-  }, []);
+  }, [idolList, setFollowedIdols]);
 
   const {
     selectedIdolId, // 선택된 아이돌 Id
@@ -88,25 +98,33 @@ function Artist() {
 
     // 팔로우 상태 확인
     const res = await api.get(
-      `/idols/${modalIdol.id}/follow-status/`
+      `/idols/${modalIdol.id}/follow-status`
     );
-    const isFollowed = res.data.is_following;
+    // console.log('res: ', res.data.data);
+    const isFollowed = res.data.data.is_following;
 
     if (isFollowed) {
       // 팔로우 된 경우 팔로우 취소 요청
       await api.delete(
-        `/idols/${modalIdol.id}/follows/`
+        `/idols/${modalIdol.id}/follows`
       );
       // 상태에서 제거
-      setFollowIdols(prev => prev.filter(idol => idol.id !== modalIdol.id));
+      const updatedFollowIdols = followIdols.filter(idol => idol.id !== modalIdol.id);
+
+      setFollowIdols(updatedFollowIdols);
+      setFollowedIdols(updatedFollowIdols);
     } else {
       // 팔로우 되지 않은 경우 팔로우 추가 요청
       await api.post(
-        `/idols/${modalIdol.id}/follows/`
+        `/idols/${modalIdol.id}/follows`
       );
-      setFollowIdols(prev => [...prev, modalIdol]);
+      
+      const updatedFollowIdols = [...followIdols, modalIdol];
+      setFollowIdols(updatedFollowIdols);        // 로컬 상태
+      setFollowedIdols(updatedFollowIdols);      // 전역 상태도 갱신
 
       navigate('/');
+      setSelectIdol(null);
     }
     // 모달 닫기 !
     setModalIdol(null);
@@ -120,13 +138,13 @@ function Artist() {
       <div className="mx-auto max-w-[1080px]">
         <div className="mt-20 px-4 md:px-8">
           <div className="text-center text-4xl font-bold">
-            <h1>{idolList.length}팀의 아티스트들을</h1>
+            <h1>{idolList?.length}팀의 아티스트들을</h1>
             <h1>Wistar에서 만나볼 수 있어요!</h1>
           </div>
           <div className="mt-20 text-2xl font-bold">
             <IdolCardList
-              idolTitle={`팔로우한 ${followIdols.length}팀의 아티스트`}
-              idolList={followIdols}
+              idolTitle={`팔로우한 ${followIdols?.length}팀의 아티스트`}
+              idolList={followIdols ?? []}
               // onCardClick={setModalIdol}
               onCardClick={idol => {
                 setModalIdol(idol);
@@ -134,12 +152,26 @@ function Artist() {
               }}
               pageType="artist"
               isVertical={false}
+              onDetailClick={(idolId)=> navigate(`/artists/${idolId}`)}
             />
           </div>
           <div className="mt-20 text-2xl font-bold">
             <IdolCardList
               idolTitle="전체 아티스트 페이지"
-              idolList={idolList}
+              idolList={idolList.map((idol) => ({
+                ...idol,
+                id: idol.id,
+                img: idol.img,
+                name: idol.name,
+                idolId: idol.id,
+                title: '',
+                type: '',
+                startDate: '',
+                endDate: '',
+                location: '',
+                description: '',
+                enName: '',
+              }))}
               // onCardClick={setModalIdol}
               onCardClick={idol => {
                 setModalIdol(idol);
@@ -152,13 +184,16 @@ function Artist() {
           </div>
           {modalIdol && ( // modalIdol 값이 존재할 때만 모달 컴포넌트 렌더링
             <IdolConfirmModal
-              idol={modalIdol} // 모달창에 쓰여지는 아이돌 이름을 모달컴포넌트로 props로 전달
-              onConfirm={handleConfirm} // '추가' 또는 '삭제' 버튼 클릭 시 handleConfirm함수 실행
-              onCancel={() => setModalIdol(null)} // 취소 버튼 클릭 시 모달 닫음
-              isAlreadySelected={followIdols.some(
-                // 현재 선택된 아이돌이 드롭다운 목록에 존재하는지 여부 확인
-                i => i.id === modalIdol.id
-              )}
+            idol={modalIdol} // 모달창에 쓰여지는 아이돌 이름을 모달컴포넌트로 props로 전달
+            onConfirm={handleConfirm} // '추가' 또는 '삭제' 버튼 클릭 시 handleConfirm함수 실행
+              onCancel={() => {
+                setModalIdol(null); 
+                setSelectIdol(null);
+              }} // 취소 버튼 클릭 시 모달 닫음
+            isAlreadySelected={followIdols?.some(
+              // 현재 선택된 아이돌이 드롭다운 목록에 존재하는지 여부 확인
+              i => i.id === modalIdol.id
+            )}
             />
           )}
         </div>

--- a/src/pages/artists/CreateArtist.tsx
+++ b/src/pages/artists/CreateArtist.tsx
@@ -34,7 +34,6 @@ function CreateArtist() {
     formData.append('object_type', 'idol');
     formData.append('object_id', `${object_id}`);
     formData.append('object_type', 'idol');
-
     formData.append('image', imageFile);
     return formData;
   }

--- a/src/pages/schedule/IdolDropdownPanel.tsx
+++ b/src/pages/schedule/IdolDropdownPanel.tsx
@@ -1,32 +1,28 @@
-import {Link} from 'react-router';
+import { useEffect } from 'react';
+import {Link, useNavigate} from 'react-router';
+import { IdolArtistsCard } from '@/components/common/Card/IdolCardList';
 
-type Idol = {
-    id: number;
-    idolId: number;
-    title: string;
-    type: string;
-    startDate: string;
-    endDate: string;
-    location: string;
-    description: string;
-    img: string;
-    name: string;
-    enName: string;
-};
 
 type Props = {
-    idols: Idol[];
+    idols: IdolArtistsCard[];
     selectedIdolId: number | null;
     setSelectIdol: (idolId: number) => void;
     handleCloseDropdown: () => void;
+    handleToggleDropdown: () => void;
 };
 
 function IdolDropdownPanel({
                                idols,
                                selectedIdolId,
                                setSelectIdol,
-                               handleCloseDropdown,
-                           }: Props) {
+    handleCloseDropdown,
+                               handleToggleDropdown,
+}: Props) {
+    const navigate = useNavigate();
+    useEffect(() => { 
+        
+    }, [idols]);
+    
     return (
         <div className="flex flex-col gap-1">
             {idols.map(idol => (
@@ -36,6 +32,8 @@ function IdolDropdownPanel({
                         onClick={() => {
                             setSelectIdol(idol.id);
                             handleCloseDropdown();
+                            handleToggleDropdown();
+                            navigate(`/schedule/${idol.id}`);
                         }}
                         className={`flex w-full items-center justify-between px-4 py-2 ${
                             selectedIdolId === idol.id && 'bg-gray-100'

--- a/src/pages/schedule/Schedule.tsx
+++ b/src/pages/schedule/Schedule.tsx
@@ -2,7 +2,7 @@ import { useIdolState } from '@store/idolStore';
 import CalendarWrapper from '@/components/common/Calendar/CalendarWrapper';
 
 function Schedule() {
-  const { idols, selectedIdolId } = useIdolState();
+  const { followedIdols, selectedIdolId } = useIdolState();
   const isLogin = true;
 
   const publicIdols = [
@@ -21,7 +21,7 @@ function Schedule() {
     },
   ];
 
-  const selectedIdol = idols.filter(idol => idol.id === selectedIdolId);
+  const selectedIdol = followedIdols.filter(idol => idol.id === selectedIdolId);
   const displayIdols = isLogin ? selectedIdol : publicIdols;
   return (
     <section className="mt-20 px-2">

--- a/src/store/idolStore.ts
+++ b/src/store/idolStore.ts
@@ -1,45 +1,32 @@
 import { create } from 'zustand/react';
 
 // Idol 삭제 필요 : 다른 페이지에서 사용하고 있는 부분이 있어 코드 삭제 후 수정 부탁드려요
-export type Idol = {
+export interface Idol {
   id: number;
-  idolId: number;
+  // idolId: number;
   title: string;
-  type: string;
-  startDate: string;
-  endDate: string;
-  location: string;
-  description: string;
   img: string;
+  // type: string;
+  startDate: string;
+  // endDate: string;
+  // location: string;
+  // description: string;
   name: string;
-  enName: string;
+  // enName: string;
 };
 
-// idols 삭제 필요 : 다른 페이지에서 사용하고 있는 부분이 있어 코드 삭제 후 수정 부탁드려요
-const idols: Idol[] = [
-  {
-    id: 1,
-    idolId: 1,
-    title: '트와이스 팬미팅',
-    type: '팬미팅',
-    startDate: '2025-05-03',
-    endDate: '2025-05-03',
-    location: '서울 올림픽홀',
-    description: '2025년 상반기 팬미팅',
-    img: '../src/assets/img/ncity.jpeg',
-    name: '트와이스',
-    enName: 'twice',
-  }
-];
-
 interface IdolState {
-  idols: Idol[]; // 삭제해야함
   selectedIdolId: number | null;
   setSelectIdol: (idolId: number) => void;
+
+  followedIdols: Idol[];
+  setFollowedIdols: (idols: Idol[]) => void;
 }
 
 export const useIdolState = create<IdolState>(set => ({
-  idols, // 삭제 해야함
   selectedIdolId: null,
   setSelectIdol: (id: number) => set({ selectedIdolId: id }),
+
+  followedIdols: [],
+  setFollowedIdols: (idols: Idol[]) => set({followedIdols: idols }),
 }));

--- a/src/store/idolStore.ts
+++ b/src/store/idolStore.ts
@@ -3,16 +3,16 @@ import { create } from 'zustand/react';
 // Idol 삭제 필요 : 다른 페이지에서 사용하고 있는 부분이 있어 코드 삭제 후 수정 부탁드려요
 export interface Idol {
   id: number;
-  // idolId: number;
+  idolId: number;
   title: string;
   img: string;
-  // type: string;
+  type: string;
   startDate: string;
-  // endDate: string;
-  // location: string;
-  // description: string;
+  endDate: string;
+  location: string;
+  description: string;
   name: string;
-  // enName: string;
+  enName: string;
 };
 
 interface IdolState {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #101 

## 📝작업 내용

홈 로고 클릭 시 드롭다운 상태 초기화 처리 추가
> 전역 상태 idols 제거 및 followedIdols 생성 후 대체
> followedIdols를 Artist 페이지에서 API 호출 후 상태로 설정
> Header와 Schedule 페이지 등에서 기존 idols 사용 코드 제거 및 followedIdols 활용하도록 리팩토링
> 드롭다운에 팔로우한 아이돌 리스트가 실시간 반영되도록 수정
> 아이돌 추가/삭제 시 전역 상태도 동기화되도록 설정
> 드롭다운에서 아이돌 선택 시 해당 스케줄 페이지로 이동하도록 기능 추가



### 스크린샷 (선택)
<img width="704" alt="image" src="https://github.com/user-attachments/assets/5e97f053-8a11-4f9e-aaf5-257acccf4bac" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
